### PR TITLE
fix: document ready js template

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/UserContentController.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/UserContentController.java
@@ -350,7 +350,5 @@ public class UserContentController {
           "  iframe.contentWindow.document.body.append(script);" +
           "})();";
 
-  private static final String DOCUMENT_READY_WRAPPER_JS_SOURCE = "if (document.readyState === 'interactive' || document.readyState === 'complete') { " +
-          "  " + PluginScriptsUtil.VAR_PLACEHOLDER_VALUE +
-          "}";
+  private static final String DOCUMENT_READY_WRAPPER_JS_SOURCE = "(function() {\n" + PluginScriptsUtil.VAR_PLACEHOLDER_VALUE + ";\n})();";
 }


### PR DESCRIPTION
### Summary

比較 Metamask 用的 reaect native webview 跟 flutter_inappwebview 後，發現主要的差別在 inject 的 script 會被經過不同的處理才丟到 Android 的 evaluateJavascript

原本 flutter_inappwebview 裡的寫法，如果 inject 的當下 document.readyState = 'loading' 的話，script 就完全不會執行。把這個 template 改成 metamask 用的 IIFE 的寫法就會 work 了

主要參考：https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java#L284-L290